### PR TITLE
[ENH] Simplify score_voxelwise

### DIFF
--- a/examples/plot_alignment_methods_benchmark.py
+++ b/examples/plot_alignment_methods_benchmark.py
@@ -97,11 +97,11 @@ roi_masker = NiftiMasker(mask_img=resampled_mask_visual).fit()
 #
 
 source_subjects = [sub for sub in sub_ids if sub != "sub-04"]
-source_train = [
+source_train_imgs = [
     concat_imgs(df[(df.subject == sub) & (df.acquisition == "ap")].path.values)
     for sub in source_subjects
 ]
-target_train = concat_imgs(
+target_train_img = concat_imgs(
     df[(df.subject == "sub-04") & (df.acquisition == "ap")].path.values
 )
 
@@ -110,11 +110,11 @@ target_train = concat_imgs(
 # * target test: PA acquisitions from the target subject (sub-04).
 #
 
-source_test = [
+source_test_imgs = [
     concat_imgs(df[(df.subject == sub) & (df.acquisition == "pa")].path.values)
     for sub in source_subjects
 ]
-target_test = concat_imgs(
+target_test_img = concat_imgs(
     df[(df.subject == "sub-04") & (df.acquisition == "pa")].path.values
 )
 
@@ -143,13 +143,21 @@ print(f"We will cluster them in {n_pieces} regions")
 
 from fmralign.embeddings.parcellation import get_labels
 
-labels = get_labels(source_train, roi_masker, n_pieces)
+labels = get_labels(source_train_imgs, roi_masker, n_pieces)
 dict_source_train = dict(
-    zip(source_subjects, [roi_masker.transform(img) for img in source_train])
+    zip(
+        source_subjects,
+        [roi_masker.transform(img) for img in source_train_imgs],
+    )
 )
 dict_source_test = dict(
-    zip(source_subjects, [roi_masker.transform(img) for img in source_test])
+    zip(
+        source_subjects,
+        [roi_masker.transform(img) for img in source_test_imgs],
+    )
 )
+target_train = roi_masker.transform(target_train_img)
+target_test = roi_masker.transform(target_test_img)
 
 ###############################################################################
 # Define the estimators, fit them and do a prediction

--- a/examples/plot_alignment_methods_benchmark.py
+++ b/examples/plot_alignment_methods_benchmark.py
@@ -183,21 +183,16 @@ for i, method in enumerate(methods):
     # Compute a mapping between the template and the new subject
     # using `target_train` and make a prediction using the left-out-data
     target_pred = group_estimator.predict_subject(
-        dict_source_test, roi_masker.transform(target_train)
+        dict_source_test, target_train
     )
 
     # Derive correlation between prediction, test
-    method_error = score_voxelwise(
-        target_test,
-        roi_masker.inverse_transform(target_pred),
-        masker=roi_masker,
-        loss="corr",
-    )
+    method_error = score_voxelwise(target_test, target_pred, loss="corr")
 
     # Store the results for plotting later
-    aligned_score = roi_masker.inverse_transform(method_error)
+    aligned_score_img = roi_masker.inverse_transform(method_error)
     titles.append(f"Correlation of prediction after {method} alignment")
-    aligned_scores.append(aligned_score)
+    aligned_scores.append(aligned_score_img)
 
 ################################################################################
 # Plot the results

--- a/examples/plot_pairwise_alignment.py
+++ b/examples/plot_pairwise_alignment.py
@@ -161,11 +161,11 @@ from nilearn import plotting
 baseline_score_img = masker.inverse_transform(baseline_score)
 aligned_score_img = masker.inverse_transform(aligned_score)
 baseline_display = plotting.plot_stat_map(
-    baseline_score, display_mode="z", vmax=1, cut_coords=[-15, -5]
+    baseline_score_img, display_mode="z", vmax=1, cut_coords=[-15, -5]
 )
 baseline_display.title("Baseline correlation wt ground truth")
 display = plotting.plot_stat_map(
-    aligned_score, display_mode="z", cut_coords=[-15, -5], vmax=1
+    aligned_score_img, display_mode="z", cut_coords=[-15, -5], vmax=1
 )
 display.title("Prediction correlation wt ground truth")
 

--- a/examples/plot_pairwise_alignment.py
+++ b/examples/plot_pairwise_alignment.py
@@ -40,9 +40,7 @@ files, df, mask = fetch_ibc_subjects_contrasts(["sub-01", "sub-02"])
 from nilearn.image import concat_imgs
 from nilearn.maskers import MultiNiftiMasker
 
-masker = MultiNiftiMasker(mask_img=mask)
-mask
-masker.fit()
+masker = MultiNiftiMasker(mask_img=mask).fit()
 
 ###############################################################################
 # Prepare the data
@@ -113,8 +111,15 @@ labels = get_labels(
 
 from fmralign import PairwiseAlignment
 
-source_train_data, target_train_data, source_test_data = masker.transform(
-    [source_train_imgs, target_train_imgs, source_test_imgs]
+(source_train_data, target_train_data, source_test_data, target_test_data) = (
+    masker.transform(
+        [
+            source_train_imgs,
+            target_train_imgs,
+            source_test_imgs,
+            target_test_imgs,
+        ]
+    )
 )
 
 alignment_estimator = PairwiseAlignment(method="procrustes", labels=labels)
@@ -138,11 +143,11 @@ from fmralign.metrics import score_voxelwise
 # original data from sub-01 made with the real PA contrasts of sub-02.
 
 target_pred_imgs = masker.inverse_transform(target_pred_data)
-baseline_score = masker.inverse_transform(
-    score_voxelwise(target_test_imgs, source_test_imgs, masker, loss="corr")
+baseline_score = score_voxelwise(
+    target_test_data, source_test_data, loss="corr"
 )
-aligned_score = masker.inverse_transform(
-    score_voxelwise(target_test_imgs, target_pred_imgs, masker, loss="corr")
+aligned_score = score_voxelwise(
+    target_test_data, target_pred_data, loss="corr"
 )
 
 ###############################################################################
@@ -153,6 +158,8 @@ aligned_score = masker.inverse_transform(
 
 from nilearn import plotting
 
+baseline_score_img = masker.inverse_transform(baseline_score)
+aligned_score_img = masker.inverse_transform(aligned_score)
 baseline_display = plotting.plot_stat_map(
     baseline_score, display_mode="z", vmax=1, cut_coords=[-15, -5]
 )

--- a/examples/plot_pairwise_roi_alignment.py
+++ b/examples/plot_pairwise_roi_alignment.py
@@ -121,8 +121,18 @@ target_test_imgs = concat_imgs(
 
 from fmralign import PairwiseAlignment
 
-source_train_data, target_train_data, source_test_data = roi_masker.transform(
-    [source_train_imgs, target_train_imgs, source_test_imgs]
+(
+    source_train_data,
+    target_train_data,
+    source_test_data,
+    target_test_data,
+) = roi_masker.transform(
+    [
+        source_train_imgs,
+        target_train_imgs,
+        source_test_imgs,
+        target_test_imgs,
+    ]
 )
 
 alignment_estimator = PairwiseAlignment(method="procrustes")
@@ -144,16 +154,11 @@ from fmralign.metrics import score_voxelwise
 # Now we use this scoring function to compare the correlation of aligned and
 # original data from sub-01 made with the real PA contrasts of sub-02.
 
-target_pred_imgs = roi_masker.inverse_transform(target_pred_data)
-baseline_score = roi_masker.inverse_transform(
-    score_voxelwise(
-        target_test_imgs, source_test_imgs, roi_masker, loss="corr"
-    )
+baseline_score = score_voxelwise(
+    target_test_data, source_test_data, loss="corr"
 )
-aligned_score = roi_masker.inverse_transform(
-    score_voxelwise(
-        target_test_imgs, target_pred_imgs, roi_masker, loss="corr"
-    )
+aligned_score = score_voxelwise(
+    target_test_data, target_pred_data, loss="corr"
 )
 
 ###############################################################################
@@ -164,6 +169,8 @@ aligned_score = roi_masker.inverse_transform(
 
 from nilearn import plotting
 
+baseline_score_img = roi_masker.inverse_transform(baseline_score)
+aligned_score_img = roi_masker.inverse_transform(aligned_score)
 baseline_display = plotting.plot_stat_map(
     baseline_score, display_mode="z", vmax=1, cut_coords=[-15, -5]
 )

--- a/examples/plot_pairwise_roi_alignment.py
+++ b/examples/plot_pairwise_roi_alignment.py
@@ -172,11 +172,11 @@ from nilearn import plotting
 baseline_score_img = roi_masker.inverse_transform(baseline_score)
 aligned_score_img = roi_masker.inverse_transform(aligned_score)
 baseline_display = plotting.plot_stat_map(
-    baseline_score, display_mode="z", vmax=1, cut_coords=[-15, -5]
+    baseline_score_img, display_mode="z", vmax=1, cut_coords=[-15, -5]
 )
 baseline_display.title("Baseline correlation wt ground truth")
 display = plotting.plot_stat_map(
-    aligned_score, display_mode="z", cut_coords=[-15, -5], vmax=1
+    aligned_score_img, display_mode="z", cut_coords=[-15, -5], vmax=1
 )
 display.title("Prediction correlation wt ground truth")
 

--- a/examples/plot_template_alignment.py
+++ b/examples/plot_template_alignment.py
@@ -79,8 +79,7 @@ left_out_subject = concat_imgs(imgs[5])
 import numpy as np
 
 masked_imgs = [masker.transform(img) for img in template_train]
-average_img = np.mean(masked_imgs, axis=0)
-average_subject = masker.inverse_transform(average_img)
+euclidean_avg = np.mean(masked_imgs, axis=0)
 
 ###############################################################################
 # Create a template from the training subjects.
@@ -123,7 +122,6 @@ pairwise_estim = PairwiseAlignment(method="procrustes", labels=labels).fit(
 )
 
 predictions_from_template = pairwise_estim.transform(left_out_data)
-predicted_img = masker.inverse_transform(predictions_from_template)
 
 ###############################################################################
 # Score the baseline and the prediction
@@ -135,12 +133,9 @@ predicted_img = masker.inverse_transform(predictions_from_template)
 
 from fmralign.metrics import score_voxelwise
 
-average_score = masker.inverse_transform(
-    score_voxelwise(left_out_subject, average_subject, masker, loss="corr")
-)
-template_img = masker.inverse_transform(procrustes_template)
-template_score = masker.inverse_transform(
-    score_voxelwise(predicted_img, template_img, masker, loss="corr")
+average_score = score_voxelwise(left_out_data, euclidean_avg, loss="corr")
+template_score = score_voxelwise(
+    predictions_from_template, procrustes_template, loss="corr"
 )
 
 ###############################################################################
@@ -151,12 +146,14 @@ template_score = masker.inverse_transform(
 
 from nilearn import plotting
 
+average_score_img = masker.inverse_transform(average_score)
+template_score_img = masker.inverse_transform(template_score)
 baseline_display = plotting.plot_stat_map(
-    average_score, display_mode="z", vmax=1, cut_coords=[-15, -5]
+    average_score_img, display_mode="z", vmax=1, cut_coords=[-15, -5]
 )
 baseline_display.title("Left-out subject correlation with group average")
 display = plotting.plot_stat_map(
-    template_score, display_mode="z", cut_coords=[-15, -5], vmax=1
+    template_score_img, display_mode="z", cut_coords=[-15, -5], vmax=1
 )
 display.title("Aligned subject correlation with Procrustes template")
 

--- a/fmralign/metrics.py
+++ b/fmralign/metrics.py
@@ -4,9 +4,7 @@ from scipy.stats import pearsonr
 from sklearn.metrics import r2_score
 
 
-def score_voxelwise(
-    ground_truth, prediction, masker, loss, multioutput="raw_values"
-):
+def score_voxelwise(X_gt, X_pred, loss, multioutput="raw_values"):
     """
     Calculate loss function for predicted, ground truth arrays.
     Supported scores are R2, correlation, and normalized
@@ -14,13 +12,10 @@ def score_voxelwise(
 
     Parameters
     ----------
-    ground_truth: 3D or 4D Niimg
-        Reference image
-    prediction : 3D or 4D Niimg
-        Same shape as `ground_truth`
-    masker: instance of NiftiMasker or MultiNiftiMasker
-        Masker to be used on ground_truth and prediction. For more information see:
-        http://nilearn.github.io/manipulating_images/masker_objects.html
+    X_gt: 2D ndarray (n_samples, n_voxels)
+        Reference data
+    X_pred : 2D ndarray (n_samples, n_voxels)
+        Same shape as `X_gt`
     loss : str in ['R2', 'corr', 'n_reconstruction_err']
         The loss function used in scoring. Default is normalized
         reconstruction error.
@@ -47,8 +42,6 @@ def score_voxelwise(
         The score or ndarray of scores if ‘multioutput’ is ‘raw_values’.
         The worst possible score is arbitrarily set to -1 for all metrics.
     """
-    X_gt = masker.transform(ground_truth)
-    X_pred = masker.transform(prediction)
 
     if loss == "R2":
         score = r2_score(X_gt, X_pred, multioutput=multioutput)

--- a/fmralign/tests/test_metrics.py
+++ b/fmralign/tests/test_metrics.py
@@ -1,41 +1,45 @@
-import nibabel as nib
 import numpy as np
-from nilearn.maskers import NiftiMasker
 from numpy.testing import assert_array_almost_equal
 
 from fmralign import metrics
 
 
 def test_score_voxelwise():
-    A = np.asarray(
-        [[[[1, 1.2, 1, 1.2, 1]], [[1, 1, 1, 0.2, 1]], [[1, -1, 1, -1, 1]]]]
+    A = np.array(
+        [
+            [1.0, 1.0, 1.0],
+            [1.2, 1.0, -1.0],
+            [1.0, 1.0, 1.0],
+            [1.2, 0.2, -1.0],
+            [1.0, 1.0, 1.0],
+        ]
     )
-    B = np.asarray(
-        [[[[0, 0.2, 0, 0.2, 0]], [[0.2, 1, 1, 1, 1]], [[-1, 1, -1, 1, -1]]]]
+    B = np.array(
+        [
+            [0.0, 0.2, -1.0],
+            [0.2, 1.0, 1.0],
+            [0.0, 1.0, -1.0],
+            [0.2, 1.0, 1.0],
+            [0.0, 1.0, -1.0],
+        ]
     )
-    im_A = nib.Nifti1Image(A, np.eye(4))
-    im_B = nib.Nifti1Image(B, np.eye(4))
-    mask_img = nib.Nifti1Image(np.ones(im_A.shape[0:3]), np.eye(4))
-    masker = NiftiMasker(mask_img=mask_img).fit()
 
     # check correlation raw_values
-    correlation1 = metrics.score_voxelwise(im_A, im_B, masker, loss="corr")
+    correlation1 = metrics.score_voxelwise(A, B, loss="corr")
     assert_array_almost_equal(correlation1, [1.0, -0.25, -1])
 
     # check correlation uniform_average
     correlation2 = metrics.score_voxelwise(
-        im_A, im_B, masker, loss="corr", multioutput="uniform_average"
+        A, B, loss="corr", multioutput="uniform_average"
     )
     assert correlation2.ndim == 0
 
     # check R2
-    r2 = metrics.score_voxelwise(im_A, im_B, masker, loss="R2")
+    r2 = metrics.score_voxelwise(A, B, loss="R2")
     assert_array_almost_equal(r2, [-1.0, -1.0, -1.0])
 
     # check normalized reconstruction
-    norm_rec = metrics.score_voxelwise(
-        im_A, im_B, masker, loss="n_reconstruction_err"
-    )
+    norm_rec = metrics.score_voxelwise(A, B, loss="n_reconstruction_err")
     assert_array_almost_equal(norm_rec, [0.14966, 0.683168, -1.0])
 
 


### PR DESCRIPTION
score_voxelwise now takes in masked images instead of niftis, making a clear contrast between alignment and masking in the examples. Closes #163