### PR TITLE
[MAINT] Remove EMD solver for ot

### DIFF
--- a/fmralign/methods/ot.py
+++ b/fmralign/methods/ot.py
@@ -77,21 +77,18 @@ class OptimalTransport(BaseAlignment):
 
             M = cdist(X.T, Y.T, metric=self.metric)
 
-            if self.solver == "exact":
-                self.R = ot.lp.emd(a, b, M) * n
-            else:
-                self.R = (
-                    ot.sinkhorn(
-                        a,
-                        b,
-                        M,
-                        self.reg,
-                        method=self.solver,
-                        numItermax=self.max_iter,
-                        stopThr=self.tol,
-                    )
-                    * n
+            self.R = (
+                ot.sinkhorn(
+                    a,
+                    b,
+                    M,
+                    self.reg,
+                    method=self.solver,
+                    numItermax=self.max_iter,
+                    stopThr=self.tol,
                 )
+                * n
+            )
             return self
 
     def transform(self, X):


### PR DESCRIPTION
Removes the EMD solver to keep only the sinkhorn variants. Additionally it removes a POT deprecation warning.