### PR TITLE
[MAINT, DOC] Update Sphinx documentation

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -27,7 +27,7 @@ Citing Nilearn and scikit-learn
 -------------------------------
 
 This package can be lightweight and efficient because it relies on great toolboxes,
-notably :nilearn:`nilearn <>` and :sklearn:`scikit-learn <>`.
+notably `nilearn <https://nilearn.github.io/stable>`_ and :sklearn:`scikit-learn <>`.
 
 A huge amount of work goes into both of these packages.
 Researchers who invest their time in developing and maintaining the package

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -56,7 +56,7 @@ extensions = [
     "numpydoc",
 ]
 
-
+imgmath_image_format = "svg"
 autosummary_generate = True
 
 autodoc_typehints = "none"
@@ -249,6 +249,7 @@ intersphinx_mapping = {
     "scipy": ("https://scipy.github.io/devdocs/", None),
     "matplotlib": ("https://matplotlib.org/stable/", None),
     "sklearn": ("https://scikit-learn.org/stable/", None),
+    "nilearn": ("https://nilearn.github.io/stable/", None),
     "nibabel": ("https://nipy.org/nibabel", None),
     "pandas": ("https://pandas.pydata.org/pandas-docs/stable/", None),
     "joblib": ("https://joblib.readthedocs.io/en/latest/", None),
@@ -257,7 +258,6 @@ intersphinx_mapping = {
 extlinks = {
     "sklearn": ("https://scikit-learn.org/stable/%s", None),
     "inria": ("https://team.inria.fr/%s", None),
-    "nilearn": ("https://nilearn.github.io/stable/%s", None),
     "nipy": ("https://nipy.org/%s", None),
 }
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -74,7 +74,7 @@ Featured examples
         Explore how to functionally align two subjects
 
   .. grid-item-card::
-    :link: auto_examples/plot_template_alignment.html
+    :link: auto_examples/plot_group_alignment.html
     :link-type: url
     :columns: 12 12 12 12
     :class-card: sd-shadow-sm
@@ -88,14 +88,14 @@ Featured examples
       .. grid-item::
         :columns: 12 4 4 4
 
-        .. image:: auto_examples/images/sphx_glr_plot_template_alignment_002.png
+        .. image:: auto_examples/images/sphx_glr_plot_group_alignment_002.png
 
       .. grid-item::
         :columns: 12 8 8 8
 
         .. div:: sd-font-weight-bold
 
-          Template alignment
+          Group alignment
 
         Align a group of subjects to create a functional template
 

--- a/doc/modules/fmralign.embeddings.connectivity.get_connectivity_features.rst
+++ b/doc/modules/fmralign.embeddings.connectivity.get_connectivity_features.rst
@@ -1,0 +1,19 @@
+﻿.. note::
+
+   This page is a reference documentation. It only explains the
+   function signature, and not how to use it. Please refer to the
+   :ref:`user guide <user_guide>` for the big picture.
+
+
+fmralign.embeddings.connectivity.get_connectivity_features
+==========================================================
+
+.. currentmodule:: fmralign.embeddings.connectivity
+
+.. autofunction:: get_connectivity_features
+
+.. include:: fmralign.embeddings.connectivity.get_connectivity_features.examples
+
+.. raw:: html
+
+    <div style='clear:both'></div>

--- a/doc/modules/fmralign.embeddings.parcellation.get_labels.rst
+++ b/doc/modules/fmralign.embeddings.parcellation.get_labels.rst
@@ -1,0 +1,19 @@
+﻿.. note::
+
+   This page is a reference documentation. It only explains the
+   function signature, and not how to use it. Please refer to the
+   :ref:`user guide <user_guide>` for the big picture.
+
+
+fmralign.embeddings.parcellation.get_labels
+===========================================
+
+.. currentmodule:: fmralign.embeddings.parcellation
+
+.. autofunction:: get_labels
+
+.. include:: fmralign.embeddings.parcellation.get_labels.examples
+
+.. raw:: html
+
+    <div style='clear:both'></div>

--- a/doc/modules/fmralign.embeddings.whole_brain.get_adjacency_from_mask.rst
+++ b/doc/modules/fmralign.embeddings.whole_brain.get_adjacency_from_mask.rst
@@ -1,0 +1,19 @@
+﻿.. note::
+
+   This page is a reference documentation. It only explains the
+   function signature, and not how to use it. Please refer to the
+   :ref:`user guide <user_guide>` for the big picture.
+
+
+fmralign.embeddings.whole_brain.get_adjacency_from_mask
+=======================================================
+
+.. currentmodule:: fmralign.embeddings.whole_brain
+
+.. autofunction:: get_adjacency_from_mask
+
+.. include:: fmralign.embeddings.whole_brain.get_adjacency_from_mask.examples
+
+.. raw:: html
+
+    <div style='clear:both'></div>

--- a/doc/modules/fmralign.methods.DetSRM.rst
+++ b/doc/modules/fmralign.methods.DetSRM.rst
@@ -1,0 +1,25 @@
+﻿
+.. note::
+
+   This page is a reference documentation. It only explains the class
+   signature, and not how to use it. Please refer to the
+   :ref:`user guide <user_guide>` for the big picture.
+
+
+fmralign.methods.DetSRM
+=======================
+
+.. currentmodule:: fmralign.methods
+
+.. autoclass:: DetSRM
+   :no-inherited-members:
+
+
+   .. automethod:: __init__
+
+
+.. include:: fmralign.methods.DetSRM.examples
+
+.. raw:: html
+
+    <div style='clear:both'></div>

--- a/doc/modules/fmralign.methods.Identity.rst
+++ b/doc/modules/fmralign.methods.Identity.rst
@@ -1,0 +1,25 @@
+﻿
+.. note::
+
+   This page is a reference documentation. It only explains the class
+   signature, and not how to use it. Please refer to the
+   :ref:`user guide <user_guide>` for the big picture.
+
+
+fmralign.methods.Identity
+=========================
+
+.. currentmodule:: fmralign.methods
+
+.. autoclass:: Identity
+   :no-inherited-members:
+
+
+   .. automethod:: __init__
+
+
+.. include:: fmralign.methods.Identity.examples
+
+.. raw:: html
+
+    <div style='clear:both'></div>

--- a/doc/modules/fmralign.methods.OptimalTransport.rst
+++ b/doc/modules/fmralign.methods.OptimalTransport.rst
@@ -1,0 +1,25 @@
+﻿
+.. note::
+
+   This page is a reference documentation. It only explains the class
+   signature, and not how to use it. Please refer to the
+   :ref:`user guide <user_guide>` for the big picture.
+
+
+fmralign.methods.OptimalTransport
+=================================
+
+.. currentmodule:: fmralign.methods
+
+.. autoclass:: OptimalTransport
+   :no-inherited-members:
+
+
+   .. automethod:: __init__
+
+
+.. include:: fmralign.methods.OptimalTransport.examples
+
+.. raw:: html
+
+    <div style='clear:both'></div>

--- a/doc/modules/fmralign.methods.Procrustes.rst
+++ b/doc/modules/fmralign.methods.Procrustes.rst
@@ -1,0 +1,25 @@
+﻿
+.. note::
+
+   This page is a reference documentation. It only explains the class
+   signature, and not how to use it. Please refer to the
+   :ref:`user guide <user_guide>` for the big picture.
+
+
+fmralign.methods.Procrustes
+===========================
+
+.. currentmodule:: fmralign.methods
+
+.. autoclass:: Procrustes
+   :no-inherited-members:
+
+
+   .. automethod:: __init__
+
+
+.. include:: fmralign.methods.Procrustes.examples
+
+.. raw:: html
+
+    <div style='clear:both'></div>

--- a/doc/modules/fmralign.methods.RidgeAlignment.rst
+++ b/doc/modules/fmralign.methods.RidgeAlignment.rst
@@ -1,0 +1,25 @@
+﻿
+.. note::
+
+   This page is a reference documentation. It only explains the class
+   signature, and not how to use it. Please refer to the
+   :ref:`user guide <user_guide>` for the big picture.
+
+
+fmralign.methods.RidgeAlignment
+===============================
+
+.. currentmodule:: fmralign.methods
+
+.. autoclass:: RidgeAlignment
+   :no-inherited-members:
+
+
+   .. automethod:: __init__
+
+
+.. include:: fmralign.methods.RidgeAlignment.examples
+
+.. raw:: html
+
+    <div style='clear:both'></div>

--- a/doc/modules/reference.rst
+++ b/doc/modules/reference.rst
@@ -47,3 +47,45 @@ uses.
   GroupAlignment
 
 .. _alignment_methods_ref:
+
+:mod:`fmralign.methods`: Alignment Methods
+==========================================================
+
+.. automodule:: fmralign.methods
+ :no-members:
+ :no-inherited-members:
+
+**Classes**:
+
+.. currentmodule:: fmralign.methods
+
+.. autosummary::
+   :toctree: generated/
+   :template: class.rst
+
+   Identity
+   DetSRM
+   Procrustes
+   RidgeAlignment
+   OptimalTransport
+
+.. _embeddings_ref:
+
+:mod:`fmralign.embeddings`: Embedding Methods
+==========================================================
+
+.. automodule:: fmralign.embeddings
+ :no-members:
+ :no-inherited-members:
+
+**Functions**:
+
+.. currentmodule:: fmralign.embeddings
+
+.. autosummary::
+   :toctree: generated/
+   :template: function.rst
+
+   connectivity.get_connectivity_features
+   parcellation.get_labels
+   whole_brain.get_adjacency_from_mask

--- a/examples/plot_alignment_methods_benchmark.py
+++ b/examples/plot_alignment_methods_benchmark.py
@@ -3,8 +3,7 @@
 """
 Alignment methods benchmark (template-based ROI case)
 =====================================================
-
-In this tutorial, we compare various methods of alignment on a template-based alignment
+In this tutorial, we compare various methods of alignment on a group-based alignment
 problem for Individual Brain Charting subjects. For each subject, we have a lot
 of functional information in the form of several task-based
 contrast per subject. We will just work here on a ROI.
@@ -75,8 +74,9 @@ plotting.plot_roi(
 # Define a masker
 # ---------------
 # We define a nilearn masker that will be used to handle relevant data.
-# For more information, visit :
-# 'http://nilearn.github.io/manipulating_images/masker_objects.html'
+# For more information, consult Nilearn's documentation on
+# :external+nilearn:ref:`masker objects <masker_objects>`.
+#
 
 from nilearn.maskers import NiftiMasker
 
@@ -89,7 +89,8 @@ roi_masker = NiftiMasker(mask_img=resampled_mask_visual).fit()
 # independent acquisitions, similar except for one acquisition parameter, the
 # encoding phase used that was either Antero-Posterior (AP) or
 # Postero-Anterior (PA). Although this induces small differences
-# in the final data, we will take  advantage of these pseudo-duplicates to define training and test samples.
+# in the final data, we will take  advantage of these pseudo-duplicates
+# to define training and test samples.
 
 # The training set:
 # * source_train: AP acquisitions from source subjects (sub-01, sub-02).
@@ -138,7 +139,7 @@ print(f"We will cluster them in {n_pieces} regions")
 # --------------------------
 # We will use intra-parcel alignments, fmralign provides a simple utility
 # to extract the labels of associated to each voxel:
-# :func:`!fmralign.embeddings.parcellation.get_labels`.
+# :func:`~fmralign.embeddings.parcellation.get_labels`.
 # We then organize the data in dictionaries of pairs of subjects names and data.
 
 from fmralign.embeddings.parcellation import get_labels
@@ -162,14 +163,16 @@ target_test = roi_masker.transform(target_test_img)
 ###############################################################################
 # Define the estimators, fit them and do a prediction
 # ---------------------------------------------------
-# On each region, we search for a transformation R that is either :
+# On each region, we search for a transformation :math:`R` that is either:
 #
-#   *  orthogonal, i.e. R orthogonal, scaling sc s.t. ||sc RX - Y ||^2 is minimized
-#   *  the optimal transport plan, which yields the minimal transport cost
-#      while respecting the mass conservation constraints. Calculated with
-#      entropic regularization.
-#   *  the shared response model (SRM), which computes a shared response space
-#      from different subjects, and then projects individual subject data into it.
+#   *  orthogonal, using :class:`~fmralign.methods.Procrustes`
+#      s.t. :math:`||sc RX - Y ||^2` is minimized, where :math:`sc` is a scaling factor
+#   *  the :class:`~fmralign.methods.OptimalTransport` plan,
+#      which yields the minimal transport cost while respecting the mass conservation constraints.
+#      Calculated with entropic regularization.
+#   *  the deterministic shared response model (:class:`~fmralign.methods.DetSRM`),
+#      which computes a shared response space from different subjects,
+#      and then projects individual subject data into it.
 #
 # Then for each method we define the estimator, fit it, predict the new image and plot
 # its correlation with the real signal. We use the identity (euclidean averaging)
@@ -225,7 +228,9 @@ plt.show()
 ###############################################################################
 # Summary:
 # --------
-# We compared TemplateAlignment methods (scaled orthogonal, optimal transport)
-# with SRM-based alignment on visual cortex activity.
-# You can see that SRM introduces more smoothness in the transformation,
-# resulting in slightly higher correlation values.
+# We compared :class:`~fmralign.alignment.group_alignment.GroupAlignment` methods
+# (i.e., :class:`~fmralign.methods.OptimalTransport`,
+# :class:`~fmralign.methods.Procrustes`)
+# with :class:`~fmralign.methods.DetSRM` alignment on visual cortex activity.
+# You can see that :class:`~fmralign.methods.DetSRM` introduces more
+# smoothness in the transformation, resulting in slightly higher correlation values.

--- a/examples/plot_alignment_simulated_2D_data.py
+++ b/examples/plot_alignment_simulated_2D_data.py
@@ -4,7 +4,7 @@
 Alignment on simulated 2D data.
 ===============================
 
-As we mentioned several times, we search for a transformation, let's call it
+In aligning, we search for a transformation, let's call it
 `R`, between the source subject data `X` and the target data `Y`. `X` and `Y`
 are arrays of dimensions `(n_voxels, n_samples)` where each image is a sample.
 So we can see each signal as a distribution where each voxel as a point
@@ -30,7 +30,7 @@ in a terminal, or use ``jupyter-notebook``.
 #   * _plot2D_samples_mat to plot 2D alignment matrix as matching between distributions.
 #   * _plot_distributions_and_alignment to plot both the distributions and the matchings
 #
-# Now you can skip this part.
+# Note that you can skip this part.
 
 import math
 
@@ -178,10 +178,10 @@ from fmralign.methods import (
 )
 
 ###############################################################################
-# Orthogonal alignment
+# Procrustes alignment
 # --------------------
-# The first idea proposed in :footcite:t:`Haxby2001` was to compute an orthogonal mixing
-# matrix `R` and a scaling `sc` such that Frobenius norm: math:
+# The first idea proposed in :footcite:t:`Haxby2011` was to compute an orthogonal mixing
+# matrix `R` and a scaling `sc` such that Frobenius norm:
 # :math:`\| sc R X - Y \|^2` is minimized.
 
 scaled_orthogonal_alignment = Procrustes()
@@ -200,8 +200,7 @@ _plot_mixing_matrix(
 ###############################################################################
 # Optimal Transport alignment
 # ---------------------------
-# Finally this package comes with a new method that build on the Wasserstein
-# distance which is well-suited for this problem. This is the framework of
+# An alternative framework is of
 # Optimal Transport that search to transport all signal from `X` to `Y`
 # while minimizing the overall cost of this transport. `R` is here the
 # optimal coupling between `X` and `Y` with entropic regularization.

--- a/examples/plot_group_alignment.py
+++ b/examples/plot_group_alignment.py
@@ -4,9 +4,10 @@ Template-based prediction.
 ==========================
 
 In this tutorial, we show how to improve inter-subject similarity using a template
-computed across multiple source subjects. For this purpose, we create a template
-using Procrustes alignment (hyperalignment) to which we align the target subject,
-using shared information. We then compare the voxelwise similarity between the
+computed across multiple source subjects. For this purpose, we leverage GroupAlignment
+to create a template, using Procrustes alignment. Leveraging the learned template,
+we align the target subject using shared information.
+We then compare the voxelwise similarity between the
 target subject and the template to the similarity between the target subject and
 the anatomical Euclidean average of the source subjects.
 
@@ -39,8 +40,8 @@ imgs, df, mask_img = fetch_ibc_subjects_contrasts(subjects)
 # Define a masker
 # -----------------
 # We define a nilearn masker that will be used to handle relevant data.
-#   For more information, visit :
-#   'http://nilearn.github.io/manipulating_images/masker_objects.html'
+# For more information, consult Nilearn's documentation on
+# :external+nilearn:ref:`masker objects <masker_objects>`.
 #
 
 from nilearn.maskers import NiftiMasker
@@ -84,8 +85,8 @@ euclidean_avg = np.mean(masked_imgs, axis=0)
 ###############################################################################
 # Create a template from the training subjects.
 # ---------------------------------------------
-# We define an estimator using the class TemplateAlignment:
-#   * We align the whole brain through 'multiple' local alignments.
+# We define an estimator using :class:`~fmralign.alignment.group_alignment.GroupAlignment`:
+#   * We align the whole brain through multiple local alignments.
 #   * These alignments are calculated on a parcellation of the brain in 150 pieces,
 #     this parcellation creates group of functionally similar voxels.
 #   * The template is created iteratively, aligning all subjects data into a

--- a/examples/plot_pairwise_alignment.py
+++ b/examples/plot_pairwise_alignment.py
@@ -3,7 +3,6 @@
 """
 Pairwise functional alignment.
 ==============================
-This is a comment
 In this tutorial, we show how to better predict new contrasts for a target
 subject using source subject corresponding contrasts and data in common.
 
@@ -33,8 +32,8 @@ files, df, mask = fetch_ibc_subjects_contrasts(["sub-01", "sub-02"])
 # Define a masker
 # ---------------
 # We define a nilearn masker that will be used to handle relevant data.
-#   For more information, visit :
-#   'http://nilearn.github.io/manipulating_images/masker_objects.html'
+# For more information, consult Nilearn's documentation on
+# :external+nilearn:ref:`masker objects <masker_objects>`.
 #
 
 from nilearn.image import concat_imgs
@@ -84,7 +83,7 @@ target_test_imgs = concat_imgs(
 # We will compute the alignment in a piecewise manner, that is, we will align
 # the data in small parcels of the brain, which are groups of functionally
 # similar voxels. To do so, we need to generate a parcellation of the
-# functional data. We use the :func:`!fmralign.embeddings.parcellation.get_labels`
+# functional data. We use the :func:`~fmralign.embeddings.parcellation.get_labels`
 # utility, which will generate a parcellation of the data in 150 pieces.
 #
 
@@ -100,12 +99,14 @@ labels = get_labels(
 ###############################################################################
 # Define the estimator, fit it and predict
 # ----------------------------------------
-# To proceed with the alignment we use :class:`fmralign.alignment.pairwise_alignment.PairwiseAlignment`,
-# which implements various functional alignment methods between data from two
-# subjects. In this example, we use the Procrustes method. Since we want to
-# align the data in parcels, we pass the labels we just computed to the
-# estimator. The labels are used to compute the alignment in each parcel
-# separately, and then to aggregate the local transformations into a global
+# To proceed with the alignment we use
+# :class:`~fmralign.alignment.pairwise_alignment.PairwiseAlignment`,
+# which implements various functional alignment methods between data from two subjects.
+# In this example, we use the :class:`~fmralign.methods.Procrustes` method.
+# Since we want to align the data in parcels,
+# we pass the labels we just computed to the estimator.
+# The labels are used to compute the alignment in each parcel separately,
+# and then to aggregate the local transformations into a global
 # transformation that is applied to the whole brain.
 #
 
@@ -142,7 +143,6 @@ from fmralign.metrics import score_voxelwise
 # Now we use this scoring function to compare the correlation of aligned and
 # original data from sub-01 made with the real PA contrasts of sub-02.
 
-target_pred_imgs = masker.inverse_transform(target_pred_data)
 baseline_score = score_voxelwise(
     target_test_data, source_test_data, loss="corr"
 )

--- a/examples/plot_pairwise_roi_alignment.py
+++ b/examples/plot_pairwise_roi_alignment.py
@@ -66,9 +66,8 @@ plot_roi(
 # Define a masker
 # -----------------
 # We define a nilearn masker that will be used to handle relevant data.
-# For more information, visit :
-# 'http://nilearn.github.io/manipulating_images/masker_objects.html'
-#
+# For more information, consult Nilearn's documentation on
+# :external+nilearn:ref:`masker objects <masker_objects>`.
 
 from nilearn.maskers import MultiNiftiMasker
 
@@ -110,10 +109,12 @@ target_test_imgs = concat_imgs(
 ###############################################################################
 # Define the estimator, fit it and predict
 # ----------------------------------------
-# To proceed with alignment we use the class PairwiseAlignment with the visual
-# mask we created before.
-# We use the scaled orthogonal method, common in the literature under the name
-# hyperalignment. As we work on a single ROI, we will search correspondence
+# To proceed with alignment, we use
+# :class:`~fmralign.alignment.pairwise_alignment.PairwiseAlignment`
+# with the visual mask we created before.
+# We use the :class:`~fmralign.methods.Procrustes` method,
+# proposed in :footcite:t:`Haxby2011` under the name "hyperalignment."
+# As we work on a single ROI, we will search correspondence
 # between the full data of each subject and so we set the number of cluster
 # n_pieces to 1. We learn alignment estimator on train data and use it to
 # predict target test data.

--- a/examples/plot_surf_alignment.py
+++ b/examples/plot_surf_alignment.py
@@ -67,7 +67,7 @@ masker = SurfaceMasker().fit([surf_source_train, surf_target_train])
 # Compute and plot a parcellation
 # -------------------------------
 # We compute a parcellation for local alignments with
-# :func:`!fmralign.embeddings.parcellation.get_labels`
+# :func:`~fmralign.embeddings.parcellation.get_labels`
 # and plot it on the surface using nilearn.
 
 from nilearn import plotting
@@ -97,8 +97,9 @@ plotting.show()
 ###############################################################################
 # Fitting the alignment operator
 # ------------------------------
-# We use the :class:`fmralign.alignment.pairwise_alignment.PairwiseAlignment` class to learn the alignment operator from
-# one subject to the other. We select the `procrutses` method to compute
+# We use the :class:`~fmralign.alignment.pairwise_alignment.PairwiseAlignment`
+# class to learn the alignment operator from one subject to the other.
+# We select the :class:`~fmralign.methods.Procrustes` method to compute
 # a rigid piecewise alignment mapping and the `ward` clustering method to
 # parcellate the cortical surface.
 
@@ -169,6 +170,7 @@ plotting_params = {
     "vmax": 3,
     "vmin": -3,
     "cmap": "coolwarm",
+    "darkness": None,
 }
 
 

--- a/fmralign/_utils.py
+++ b/fmralign/_utils.py
@@ -11,10 +11,10 @@ def save_alignment(alignment_estimator, output_path):
 
     Parameters
     ----------
-    alignment_estimator : :obj:`PairwiseAlignment` or :obj:`TemplateAlignment`
+    alignment_estimator : :obj:`PairwiseAlignment` or :obj:`GroupAlignment`
         The alignment estimator object to be saved.
         It should be an instance of either `PairwiseAlignment` or
-        `TemplateAlignment`.
+        `GroupAlignment`.
         The object should have been fitted before saving.
     output_path : str or Path
         Path to the file or directory where the model will be saved.
@@ -58,10 +58,10 @@ def load_alignment(input_path):
 
     Returns
     -------
-    alignment_estimator : :obj:`PairwiseAlignment` or :obj:`TemplateAlignment`
+    alignment_estimator : :obj:`PairwiseAlignment` or :obj:`GroupAlignment`
         The loaded alignment estimator object.
         It will be an instance of either `PairwiseAlignment` or
-        `TemplateAlignment`, depending on what was saved.
+        `GroupAlignment`, depending on what was saved.
 
     Raises
     ------

--- a/fmralign/alignment/group_alignment.py
+++ b/fmralign/alignment/group_alignment.py
@@ -200,7 +200,7 @@ class GroupAlignment(BaseEstimator, TransformerMixin):
         Will raise AttributeError if called.
         """
         raise AttributeError(
-            "type object 'GroupwiseAlignment' has no 'fit_transform' attribute"
+            "type object 'GroupAlignment' has no 'fit_transform' attribute"
         )
 
     def predict_subject(self, X_test, Y_new):

--- a/fmralign/methods/procrustes.py
+++ b/fmralign/methods/procrustes.py
@@ -5,9 +5,9 @@ from fmralign.methods.base import BaseAlignment
 
 
 def scaled_procrustes(X, Y, scaling=False, primal=None):
-    """
+    r"""
     Compute a mixing matrix R and a scaling sc such that Frobenius norm
-    ||sc RX - Y||^2 is minimized and R is an orthogonal matrix
+    :math:`||sc RX - Y||^2` is minimized and R is an orthogonal matrix
 
     Parameters
     ----------
@@ -59,17 +59,17 @@ def scaled_procrustes(X, Y, scaling=False, primal=None):
 
 
 class Procrustes(BaseAlignment):
-    """
+    r"""
     Compute a orthogonal mixing matrix R and a scaling sc.
-    These are calculated such that Frobenius norm ||sc RX - Y||^2 is minimized.
+    These are calculated such that Frobenius norm :math:`||sc RX - Y||^2` is minimized.
 
     Parameters
-    -----------
+    ----------
     scaling : boolean, optional
         Determines whether a scaling parameter is applied to improve transform.
 
     Attributes
-    -----------
+    ----------
     R : ndarray (n_features, n_features)
         Optimal orthogonal transform
     scale: float,
@@ -81,11 +81,11 @@ class Procrustes(BaseAlignment):
         self.scale = 1
 
     def fit(self, X, Y):
-        """
-        Fit orthogonal R s.t. ||sc XR - Y||^2
+        r"""
+        Fit orthogonal R s.t. :math:`||sc XR - Y||^2`
 
         Parameters
-        -----------
+        ----------
         X: (n_samples, n_features) nd array
             source data
         Y: (n_samples, n_features) nd array

--- a/fmralign/methods/ridge.py
+++ b/fmralign/methods/ridge.py
@@ -4,9 +4,9 @@ from fmralign.methods.base import BaseAlignment
 
 
 class RidgeAlignment(BaseAlignment):
-    """
+    r"""
     Compute a scikit-estimator R using a mixing matrix M s.t Frobenius
-    norm || XM - Y ||^2 + alpha * ||M||^2 is minimized.
+    norm :math:`|| XM - Y ||^2 + alpha * ||M||^2` is minimized.
     cross-validation is used to find the optimal alpha.
 
     Parameters
@@ -33,20 +33,22 @@ class RidgeAlignment(BaseAlignment):
         self.cv = cv
 
     def fit(self, X, Y):
-        """
-        Fit R s.t. || XR - Y ||^2 + alpha ||R||^2 is minimized with cv
+        r"""
+        Fit R s.t. :math:`|| XR - Y ||^2 + alpha ||R||^2` is minimized with cv
 
         Parameters
-        -----------
+        ----------
         X: (n_samples, n_features) nd array
             source data
         Y: (n_samples, n_features) nd array
             target data
         """
         self.R = RidgeCV(
-            alphas=self.alphas
-            if self.alphas is not None
-            else [0.1, 1.0, 10.0, 100, 1000],
+            alphas=(
+                self.alphas
+                if self.alphas is not None
+                else [0.1, 1.0, 10.0, 100, 1000]
+            ),
             fit_intercept=True,
             scoring="r2",
             cv=self.cv,

--- a/fmralign/methods/srm.py
+++ b/fmralign/methods/srm.py
@@ -21,11 +21,11 @@ class DetSRM(BaseAlignment):
         self.n_components = n_components
 
     def fit(self, X, S):
-        """
-        Fit orthogonal W s.t. ||X - SW||^2 is minimized
+        r"""
+        Fit orthogonal W s.t. :math:`||X - SW||^2` is minimized
 
         Parameters
-        -----------
+        ----------
         X: (n_samples, n_features) ndarray
             Source data
         S: (n_samples, n_components) ndarray

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,14 @@ doc = [
 # For running unit and docstring tests
 test = ["coverage", "pytest>=6.0.0", "pytest-cov"]
 
+[tool.codespell]
+check-hidden = true
+ignore-words = '.github/codespell_ignore_words.txt'
+# ignore-regex = ''
+ignore-words-list = 'nd,ot'
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = '.git*,*.css'
+
 [tool.hatch.build.hooks.vcs]
 version-file = "fmralign/_version.py"
 
@@ -112,11 +120,3 @@ max-branches = 48
 max-returns = 7
 # https://docs.astral.sh/ruff/settings/#lint_pylint_max-statements
 max-statements = 151
-
-[tool.codespell]
-# Ref: https://github.com/codespell-project/codespell#using-a-config-file
-skip = '.git*,*.css'
-check-hidden = true
-# ignore-regex = ''
-ignore-words-list = 'nd,ot'
-ignore-words = '.github/codespell_ignore_words.txt'


### PR DESCRIPTION
Resolves #165  and :

- Removes reference to `TemplateAlignment` in documentation
- Expands the [Reference documentation](https://fmralign.github.io/fmralign/modules/reference.html) in the User Guide
- Links to relevant classes and functions throughout the examples (e.g., adds direct links to the `OptimalTransport` class, as referenced).
- Updates external Nilearn links throughout the examples s.t. no longer non-functional hyperlinks
- Adjust line breaks to align more with semantic line breaks