### PR TITLE
[MAINT] Update workflows to support python 3.14

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -46,6 +46,6 @@ jobs:
         if: success()
         uses: codecov/codecov-action@v6
         with:
-          flags: ${{ matrix.os }}_${{ matrix.py }}_${{ matrix.env }}
+          flags: py${{ matrix.python-version }}
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -8,28 +8,44 @@ on:
     branches:
       - "*"
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
-
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+
       - name: Install uv and set the python version
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Set up Python ${{ matrix.python-version }}
-        run: uv python install ${{ matrix.python-version }}
-      - name: Install Venv
-        run: uv venv
-      - name: Install Dependencies
-        run: uv pip install -e ".[dev]"
+          enable-cache: true
+
+      - name: Install dependencies
+        run: |
+          uv venv
+          uv pip install -e ".[dev]"
+
       - name: Run Ruff check
         run: uv run ruff check --output-format=github
+
       - name: Test with pytest
-        run: uv run pytest
+        run: uv run pytest --cov --cov-report=xml
+
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        if: success()
+        uses: codecov/codecov-action@v6
+        with:
+          flags: ${{ matrix.os }}_${{ matrix.py }}_${{ matrix.env }}
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # fmralign
 
 ![build](https://img.shields.io/github/actions/workflow/status/fmralign/fmralign/testing.yml?event=push&style=for-the-badge)
-![python version](https://img.shields.io/badge/python-3.10_|_3.11_|_3.12_|_3.13-blue?style=for-the-badge)
+![python version](https://img.shields.io/badge/python-3.10_|_3.11_|_3.12_|_3.13_|_3.14-blue?style=for-the-badge)
 ![license](https://img.shields.io/github/license/fmralign/fmralign?style=for-the-badge)
 
 [Functional alignment for fMRI](https://fmralign.github.io/fmralign-docs) (functional Magnetic Resonance Imaging) data.


### PR DESCRIPTION
Closes #182 | Adds support for python 3.14 and upgrades the testing workflow.