### PR TITLE
[MAINT] Compliance with RF101 and RF103

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,10 +104,6 @@ skip-magic-trailing-comma = false
 
 [tool.ruff.lint]
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
-extend-select = [
-    "B",  # flake8-bugbear
-    "UP"  # pyupgrade
-]
 fixable = ["ALL"]
 ignore = [
     "E501"  # Line too long
@@ -115,7 +111,9 @@ ignore = [
 select = [
     "E",  # pycodestyle
     "F",  # pyflakes
-    "I"  # isort
+    "I",  # isort
+    "B",  # flake8-bugbear
+    "UP"  # pyupgrade
 ]
 unfixable = []
 


### PR DESCRIPTION
Turns out B and UP rules must be included in select instead of extend-select. This matches nilearn's toml.