### PR TITLE
[MAINT] Subtitute pre-commit for prek in workflows

### DIFF
--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -10,5 +10,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
-      - uses: pre-commit/action@v3.0.1
+      - uses: j178/prek-action@v2


### PR DESCRIPTION
Substitutes the pre-commit action to the faster prek action for CI acceleration.

EDIT: after running the linting workflow, time drops from 27s to 7s.